### PR TITLE
eks: add sg for cluster access

### DIFF
--- a/jarvis-infra-states/eks/node-groups.tf
+++ b/jarvis-infra-states/eks/node-groups.tf
@@ -40,7 +40,7 @@ module "default_nodes" {
 
   vpc_id                 = data.terraform_remote_state.vpc.outputs.vpc_id
   subnet_ids             = [data.terraform_remote_state.vpc.outputs.public_subnet_ids[count.index]]
-  vpc_security_group_ids = [module.eks.node_security_group_id]
+  vpc_security_group_ids = [module.eks.node_security_group_id, aws_security_group.cluster_access.id]
 
   create_security_group = false
   create_iam_role       = false


### PR DESCRIPTION
eks 내부 통신을 위해 node group module에 security group을 추가합니다.

sg 리소스는 만들어두었는데 여기 추가하는걸 잊었네요..🥲